### PR TITLE
adding METEOR_BUILD_PARAMS allowing to add build parameters (.e.g "--…

### DIFF
--- a/base/scripts/lib/build_app.sh
+++ b/base/scripts/lib/build_app.sh
@@ -18,7 +18,8 @@ export
 meteor build \
   --allow-superuser \
   --directory $BUNDLE_DIR \
-  --server=http://localhost:3000
+  --server=http://localhost:3000 \
+  $METEOR_BUILD_PARAMS
 
 echo "=> Printing Meteor Node information..."
 echo "  => platform"


### PR DESCRIPTION
adding METEOR_BUILD_PARAMS to meteor build command in "\base\scripts\lib\build_app.sh" allowing to add build parameters (.e.g "--debug")

Parameter can be used in meteor run by adding
-e METEOR_BUILD_PARAMS="--debug"
