### PR TITLE
Pass termination signal to meteor process

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -14,4 +14,4 @@ RUN bash $METEORD_DIR/lib/install_phantomjs.sh
 RUN bash $METEORD_DIR/lib/cleanup.sh
 
 EXPOSE 80
-ENTRYPOINT bash $METEORD_DIR/run_app.sh
+ENTRYPOINT ["bash", "/opt/meteord/run_app.sh"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -14,4 +14,5 @@ RUN bash $METEORD_DIR/lib/install_phantomjs.sh
 RUN bash $METEORD_DIR/lib/cleanup.sh
 
 EXPOSE 80
-ENTRYPOINT ["bash", "/opt/meteord/run_app.sh"]
+RUN chmod +x $METEORD_DIR/run_app.sh
+ENTRYPOINT exec $METEORD_DIR/run_app.sh

--- a/base/scripts/run_app.sh
+++ b/base/scripts/run_app.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 if [ -d /bundle ]; then

--- a/base/scripts/run_app.sh
+++ b/base/scripts/run_app.sh
@@ -47,4 +47,4 @@ fi
 export PORT=${PORT:-80}
 
 echo "=> Starting meteor app on port:$PORT"
-node main.js
+exec node main.js

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -19,3 +19,5 @@ bash ./test_meteor_app_with_devbuild.sh
 
 bash ./test_phantomjs.sh
 bash ./test_no_app.sh
+
+bash ./test_sigterm.sh

--- a/tests/test_sigterm.sh
+++ b/tests/test_sigterm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+: ${NODE_VERSION?"NODE_VERSION has not been set."}
+
+set -x
+
+function clean() {
+  docker rm -f meteor-app
+  rm -rf hello
+}
+
+cd /tmp
+clean
+
+meteor create --release 1.6.0.1 hello
+cd hello
+echo "process.on('SIGTERM', function () { console.log('SIGTERM RECEIVED'); });" >> server/main.js
+
+meteor build --architecture=os.linux.x86_64 ./
+docker run -d \
+    --name meteor-app \
+    -e ROOT_URL=http://yourapp_dot_com \
+    -v /tmp/hello/:/bundle \
+    -p 8080:80 \
+    abernix/meteord:base
+
+sleep 50
+
+docker stop meteor-app
+found=`docker logs meteor-app | grep -c "SIGTERM RECEIVED"`
+clean
+
+if [[ $found != 1 ]]; then
+  echo "Failed: Meteor app"
+  exit 1
+fi


### PR DESCRIPTION
Since docker will pass termination signal only to process with pid=1 and bash script is executed in new process it is not currently possible for meteor process to handle SIGTERM signal. This patch makes meteor process to run with pid=1 so when `docker stop` command is invoked it will send SIGTERM signal to meteor process which can be later handled by the app in following way:

```javascript
process.on('SIGTERM', function () { /* handle */ });
```

This is used by [ddp-graceful-shutdown](https://github.com/meteor/ddp-graceful-shutdown) package.

This PR has some cons and limitations:

- only works with `abernix/meterod:base` image
- `/opt/meteord` path is hardcoded in ENTRYPOINT command. I couldn't find a way to use docker's ENV nor ARG commands here.
